### PR TITLE
fix: handle partial yelling and shorter punctuation

### DIFF
--- a/lib/rules/no-punctuation-spam.js
+++ b/lib/rules/no-punctuation-spam.js
@@ -15,7 +15,8 @@ module.exports = {
   },
 
   create(context) {
-    const PUNCTUATION_SPAM_REGEX = /([!?\.])\1{2,}/;
+    // Match any sequence of at least two punctuation marks
+    const PUNCTUATION_SPAM_REGEX = /[!?\.]{2,}/;
 
     return {
       Program() {

--- a/lib/rules/no-uppercase-comments.js
+++ b/lib/rules/no-uppercase-comments.js
@@ -4,7 +4,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'disallow all-uppercase comments',
+      description: 'disallow comments that are mostly uppercase',
       category: 'Stylistic Issues',
       recommended: false,
     },
@@ -20,8 +20,13 @@ module.exports = {
         const comments = context.getSourceCode().getAllComments();
         for (const comment of comments) {
           const text = comment.value.trim();
-          // check for uppercase yelling in comments
-          if (text.length > 0 && text === text.toUpperCase() && /[A-Z]/.test(text)) {
+          // calculate ratio of uppercase letters to total letters
+          const letters = text.match(/[a-z]/gi) || [];
+          const uppercaseCount = (text.match(/[A-Z]/g) || []).length;
+          const ratio = letters.length === 0 ? 0 : uppercaseCount / letters.length;
+
+          // report comments that are mostly uppercase (>50%)
+          if (ratio > 0.5) {
             context.report({
               loc: comment.loc,
               messageId: 'yelling',


### PR DESCRIPTION
## Summary
- catch comments that are mostly uppercase
- detect shorter punctuation sequences

## Testing
- `npm test` *(fails: Cannot find module 'eslint')*

------
https://chatgpt.com/codex/tasks/task_e_686f79a99c108329af0d07877d108486