### PR TITLE
feat: allow short abbreviations in uppercase rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.0
+- `no-uppercase-comments` now allows abbreviations up to four letters.
+
 ## 1.0.0
 - Initial release with two rules:
   - `no-uppercase-comments`

--- a/README.md
+++ b/README.md
@@ -25,7 +25,15 @@ Add `calm-comments` to the plugins section and enable the rules you want.
 ## Rules
 
 ### `no-uppercase-comments`
-Disallows comments that are entirely uppercase.
+Disallows comments that are entirely uppercase. Short abbreviations up to four
+letters such as `NASA`, `HTML` or `KISS` are allowed. Words longer than four
+letters like `UNESCO` will still be reported.
+
+Yelling in an academic sense is when a text is written in all-uppercase, which
+in most educated contexts is perceived as shouting. The rule tries to walk a
+tight line between letting short outbursts or curses pass while preventing long
+blocks of uppercase that clearly read like yelling. Like any ESLint rule it is
+opinionated and can cause friction for some developers.
 
 #### BAD
 ```js

--- a/README.md
+++ b/README.md
@@ -25,15 +25,18 @@ Add `calm-comments` to the plugins section and enable the rules you want.
 ## Rules
 
 ### `no-uppercase-comments`
-Disallows comments that are entirely uppercase. Short abbreviations up to four
-letters such as `NASA`, `HTML` or `KISS` are allowed. Words longer than four
-letters like `UNESCO` will still be reported.
+Disallows comments that are entirely or mostly uppercase.
 
 Yelling in an academic sense is when a text is written in all-uppercase, which
 in most educated contexts is perceived as shouting. The rule tries to walk a
-tight line between letting short outbursts or curses pass while preventing long
+tight line between tolerating short outbursts or curses while preventing long
 blocks of uppercase that clearly read like yelling. Like any ESLint rule it is
-opinionated and can cause friction for some developers.
+opinionated and can cause friction for some developers ¯\\_(ツ)_/¯. Curse speeches are still possible despite using this linting rule when maintaining [properly-cased and civil, yet *extremely legendary*™️ manners](https://github.com/gco/xee/blob/4fa3a6d609dd72b8493e52a68f316f7a02903276/XeePhotoshopLoader.m#L108).
+
+#### Abbreviation tradeoff
+Regardless of relevance, short abbreviations of up to four
+letters such as `NASA`, `HTML` or `KISS` are allowed. Words longer than four
+letters like `UNESCO` would be reported as rule violations.
 
 #### BAD
 ```js

--- a/lib/rules/no-uppercase-comments.js
+++ b/lib/rules/no-uppercase-comments.js
@@ -25,6 +25,11 @@ module.exports = {
           const uppercaseCount = (text.match(/[A-Z]/g) || []).length;
           const ratio = letters.length === 0 ? 0 : uppercaseCount / letters.length;
 
+          // Allow comments that are short abbreviations of up to 4 letters
+          if (letters.length <= 4) {
+            continue;
+          }
+
           // report comments that are mostly uppercase (>50%)
           if (ratio > 0.5) {
             context.report({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-calm-comments",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "ESLint plugin that keeps comments calm and collected (=more readable).",
   "main": "index.js",
   "scripts": {

--- a/tests/no-uppercase-comments.test.js
+++ b/tests/no-uppercase-comments.test.js
@@ -7,10 +7,14 @@ tester.run('no-uppercase-comments', rule, {
   valid: [
     { code: '// This is calm.' },
     { code: '// Not all CAPS here.' },
+    { code: '// KISS' }, // abbreviation
+    { code: '// HTML' }, // abbreviation
+    { code: '// NASA' }, // abbreviation
   ],
   invalid: [
     { code: '// THIS IS YELLING', errors: [{ messageId: 'yelling' }] },
     { code: '// this is PARTIAL YELLING', errors: [{ messageId: 'yelling' }] },
     { code: '// WHY IS THE CODE NOT WORKING?', errors: [{ messageId: 'yelling' }] },
+    { code: '// UNESCO', errors: [{ messageId: 'yelling' }] },
   ],
 });

--- a/tests/no-uppercase-comments.test.js
+++ b/tests/no-uppercase-comments.test.js
@@ -7,14 +7,16 @@ tester.run('no-uppercase-comments', rule, {
   valid: [
     { code: '// This is calm.' },
     { code: '// Not all CAPS here.' },
+    { code: '//also accepted without a space prefix' },
     { code: '// KISS' }, // abbreviation
     { code: '// HTML' }, // abbreviation
     { code: '// NASA' }, // abbreviation
+    { code: '//' }, // empty comment
   ],
   invalid: [
     { code: '// THIS IS YELLING', errors: [{ messageId: 'yelling' }] },
     { code: '// this is PARTIAL YELLING', errors: [{ messageId: 'yelling' }] },
     { code: '// WHY IS THE CODE NOT WORKING?', errors: [{ messageId: 'yelling' }] },
-    { code: '// UNESCO', errors: [{ messageId: 'yelling' }] },
+    { code: '// YELLING', errors: [{ messageId: 'yelling' }] }, // too long to be an abbreviation
   ],
 });


### PR DESCRIPTION
## Summary
- allow uppercase comments when they are short abbreviations
- document the reasoning and trade-offs
- test short abbreviations
- bump version to 1.1.0
